### PR TITLE
 Remove automatic insertion of DOCTYPE, <html>, <body> 

### DIFF
--- a/wp-anchor-header.php
+++ b/wp-anchor-header.php
@@ -67,6 +67,7 @@ class Anchor_Header {
 		// Modify state
 		$libxml_previous_state = libxml_use_internal_errors( true );
 		$doc->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ) );
+		$doc->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		// handle errors
 		libxml_clear_errors();
 		// restore


### PR DESCRIPTION
DOMDocument (by default) generates a complete HTML document that includes opening and closing tags.

So an extra…

```
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
<html><body>
```

…is inserted into the page at the beginning of `the_content()`, and also closing tags at the end of it.

Using `loadHTML()` with a few extra parameters solves this.
More info: https://stackoverflow.com/a/22490902